### PR TITLE
Fixed bug when adding to the beginning of Swiper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <!-- Add-on version number. Snapshot is good for development,
     but when publishing, make sure to use semantic version number like '1.0.0'.
     See https://semver.org/ -->
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <!-- Change this. The name is used when you publish to Vaadin Directory.
     Make sure to use a unique name by first searching at https://vaadin.com/directory -->

--- a/src/main/java/org/vaadin/addons/online/hatsunemiku/diamond/swiper/Swiper.java
+++ b/src/main/java/org/vaadin/addons/online/hatsunemiku/diamond/swiper/Swiper.java
@@ -150,7 +150,7 @@ public class Swiper extends Component implements HasComponents {
   public void addAtBeginning(Component... components) {
     List<Component> slides = getSlidesFromComponents(components);
 
-    for (int i = slides.size() - 1; i >= 0; i--) {
+    for (int i = 0; i < slides.size(); i++) {
       getElement().insertChild(i, slides.get(i).getElement());
     }
   }
@@ -202,8 +202,8 @@ public class Swiper extends Component implements HasComponents {
 
     List<Component> slides = getSlidesFromComponents(components);
 
-    for (int i = slides.size() - 1; i >= 0; i--) {
-      getElement().insertChild(index, slides.get(i).getElement());
+    for (int i = 0; i < slides.size(); i++) {
+      getElement().insertChild(index + i, slides.get(i).getElement());
     }
   }
 


### PR DESCRIPTION
When adding to the beginning, it would accidentally write out of bounds when Swiper has too few children yet

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>