### PR TITLE
Saving Language Direction State

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <!-- Add-on version number. Snapshot is good for development,
     but when publishing, make sure to use semantic version number like '1.0.0'.
     See https://semver.org/ -->
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 
     <!-- Change this. The name is used when you publish to Vaadin Directory.
     Make sure to use a unique name by first searching at https://vaadin.com/directory -->

--- a/src/main/java/org/vaadin/addons/online/hatsunemiku/diamond/swiper/Swiper.java
+++ b/src/main/java/org/vaadin/addons/online/hatsunemiku/diamond/swiper/Swiper.java
@@ -86,6 +86,11 @@ public class Swiper extends Component implements HasComponents {
   private static final Logger logger = LoggerFactory.getLogger(Swiper.class);
   private final boolean lazyLoading;
   private int activeIndex;
+  /**
+   * The {@link LanguageDirection language direction} of the Swiper. This is NOT updated if the DOM
+   * is manipulated directly.
+   */
+  private LanguageDirection languageDirection;
 
   public Swiper() {
     getElement().setAttribute("events-prefix", "flow-swiper-");
@@ -1482,5 +1487,13 @@ public class Swiper extends Component implements HasComponents {
     getElement().callJsFunction("swiper.updateSlidesClasses");
   }
 
-
+  /**
+   * Returns the current {@link LanguageDirection language direction} of the Swiper. This value is
+   * NOT updated when the DOM is manipulated directly.
+   *
+   * @return The current {@link LanguageDirection language direction} of the Swiper.
+   */
+  public LanguageDirection getLanguageDirection() {
+    return languageDirection;
+  }
 }

--- a/src/main/java/org/vaadin/addons/online/hatsunemiku/diamond/swiper/Swiper.java
+++ b/src/main/java/org/vaadin/addons/online/hatsunemiku/diamond/swiper/Swiper.java
@@ -1161,6 +1161,7 @@ public class Swiper extends Component implements HasComponents {
    */
   public void changeLanguageDirection(LanguageDirection direction) {
     getElement().callJsFunction("swiper.changeLanguageDirection", direction.value);
+    this.languageDirection = direction;
   }
 
   /**


### PR DESCRIPTION
- Bumps version to 1.2.0
- Keeps the current LanguageDirection state in a variable in the Swiper instance
- Updates the LanguageDirection state when calling Swiper#changeLanguageDirection
- Added a Getter for the LanguageDirection state in Swiper

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>